### PR TITLE
Implemented IInventoryItem interface

### DIFF
--- a/code/IInventoryItem.cs
+++ b/code/IInventoryItem.cs
@@ -1,0 +1,144 @@
+using Sandbox;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Conna.Inventory;
+
+public interface IInventoryItem : IValid
+{
+	/// <summary>
+	/// Is this item valid?
+	/// </summary>
+	public new bool IsValid { get; set; }
+
+	/// <summary>
+	/// The <see cref="InventoryContainer"/> that holds this item.
+	/// </summary>
+	public InventoryContainer Parent { get; set; }
+
+	/// <summary>
+	/// If this item is dropped this will be the <see cref="ItemEntity"/> that holds it.
+	/// </summary>
+	public ItemEntity WorldEntity { get; }
+
+	/// <summary>
+	/// Is this item currently dropped (does it have a world entity?)
+	/// </summary>
+	public bool IsWorldEntity { get; }
+
+	/// <summary>
+	/// When the item is created this will be its default stack size.
+	/// </summary>
+	public ushort DefaultStackSize { get; }
+
+	/// <summary>
+	/// The maximum amount of this item that can be stacked.
+	/// </summary>
+	public ushort MaxStackSize { get; }
+
+	/// <summary>
+	/// The world model to use when this item is dropped.
+	/// </summary>
+	public string WorldModel { get; }
+
+	/// <summary>
+	/// The unique id of this item.
+	/// </summary>
+	public string UniqueId { get; }
+
+	/// <summary>
+	/// Tags associated with the item.
+	/// </summary>
+	public IReadOnlySet<string> Tags { get; }
+
+	/// <summary>
+	/// What is the current stack size of the item?
+	/// </summary>
+	public ushort StackSize { get; set; }
+
+	/// <summary>
+	/// Has item data changed for this item since it was last networked?
+	/// </summary>
+	public bool IsDirty { get; set; }
+
+	/// <summary>
+	/// The item id of this item.
+	/// </summary>
+	public ulong ItemId { get; }
+
+	/// <summary>
+	/// The slot this item currently sits in within its <see cref="InventoryContainer"/>.
+	/// </summary>
+	public ushort SlotId { get; set; }
+
+	/// <summary>
+	/// Is this item the same type as another item?
+	/// </summary>
+	/// <param name="other"></param>
+	/// <returns></returns>
+	public bool IsSameType(IInventoryItem other);
+
+	/// <summary>
+	/// Should this item stack with another item?
+	/// </summary>
+	/// <param name="other"></param>
+	/// <returns></returns>
+	public bool CanStackWith(IInventoryItem other);
+
+	/// <summary>
+	/// Can this item be swapped with another item?
+	/// </summary>
+	/// <param name="other"></param>
+	/// <returns></returns>
+	public bool OnTrySwap(IInventoryItem other);
+
+	/// <summary>
+	/// Set (override) the item id of this item.
+	/// </summary>
+	/// <param name="itemId"></param>
+	public void SetItemId(ulong itemId);
+
+	/// <summary>
+	/// Set the world entity of this item.
+	/// </summary>
+	/// <param name="entity"></param>
+	public void SetWorldEntity(ItemEntity entity);
+
+	/// <summary>
+	/// Clear this item's world entity.
+	/// </summary>
+	public void ClearWorldEntity();
+
+	/// <summary>
+	/// Serialize the item into a byte array.
+	/// </summary>
+	/// <returns></returns>
+	public byte[] Serialize();
+
+	/// <summary>
+	/// Called when the item is created.
+	/// </summary>
+	public void OnCreated();
+
+	/// <summary>
+	/// Remove this item from its parent <see cref="InventoryContainer"/>.
+	/// </summary>
+	public void Remove();
+
+	/// <summary>
+	/// Called when the item is removed.
+	/// </summary>
+	public void OnRemoved();
+
+	/// <summary>
+	/// Serialize this item ready for sending over the network.
+	/// </summary>
+	/// <param name="writer"></param>
+	public void Write(BinaryWriter writer);
+
+	/// <summary>
+	/// Deserialize this item from data sent over the network.
+	/// </summary>
+	/// <param name="reader"></param>
+	public void Read(BinaryReader reader);
+}

--- a/code/InventoryItem.cs
+++ b/code/InventoryItem.cs
@@ -9,7 +9,7 @@ namespace Conna.Inventory;
 /// <summary>
 /// An inventory item instance.
 /// </summary>
-public class InventoryItem : IValid
+public class InventoryItem : IInventoryItem
 {
 	/// <summary>
 	/// The <see cref="InventoryContainer"/> that holds this item.
@@ -110,7 +110,7 @@ public class InventoryItem : IValid
 	/// </summary>
 	/// <param name="data"></param>
 	/// <returns></returns>
-	public static InventoryItem Deserialize( byte[] data )
+	public static IInventoryItem Deserialize( byte[] data )
 	{
 		using ( var stream = new MemoryStream( data ) )
 		{
@@ -253,7 +253,7 @@ public class InventoryItem : IValid
 	/// Replace this item in its parent <see cref="InventoryContainer"/> with another item.
 	/// </summary>
 	/// <param name="other"></param>
-	public void Replace( InventoryItem other )
+	public void Replace( IInventoryItem other )
 	{
 		if ( Parent.IsValid() )
 		{
@@ -261,7 +261,7 @@ public class InventoryItem : IValid
 		}
 	}
 
-	public virtual bool OnTrySwap( InventoryItem other )
+	public virtual bool OnTrySwap( IInventoryItem other )
 	{
 		return true;
 	}
@@ -271,7 +271,7 @@ public class InventoryItem : IValid
 	/// </summary>
 	/// <param name="other"></param>
 	/// <returns></returns>
-	public virtual bool IsSameType( InventoryItem other )
+	public virtual bool IsSameType( IInventoryItem other )
 	{
 		return (GetType() == other.GetType() && UniqueId == other.UniqueId);
 	}
@@ -281,7 +281,7 @@ public class InventoryItem : IValid
 	/// </summary>
 	/// <param name="other"></param>
 	/// <returns></returns>
-	public virtual bool CanStackWith( InventoryItem other )
+	public virtual bool CanStackWith( IInventoryItem other )
 	{
 		return true;
 	}

--- a/code/ItemClassAttribute.cs
+++ b/code/ItemClassAttribute.cs
@@ -3,7 +3,7 @@
 namespace Conna.Inventory;
 
 /// <summary>
-/// Use this attribute on a class derived from <see cref="ItemResource"/> to tell it what <see cref="InventoryItem"/> class to use.
+/// Use this attribute on a class derived from <see cref="ItemResource"/> to tell it what <see cref="IInventoryItem"/> class to use.
 /// </summary>
 public class ItemClassAttribute : Attribute
 {

--- a/code/ItemEntity.cs
+++ b/code/ItemEntity.cs
@@ -11,9 +11,9 @@ public partial class ItemEntity : ModelEntity
 	public TimeSince TimeSinceSpawned { get; set; }
 
 	[Net] private NetInventoryItem InternalItem { get; set; }
-	public InventoryItem Item => InternalItem.Value;
+	public IInventoryItem Item => InternalItem.Value;
 
-	public void SetItem( InventoryItem item )
+	public void SetItem( IInventoryItem item )
 	{
 		var worldModel = !string.IsNullOrEmpty( item.WorldModel ) ? item.WorldModel : "models/sbox_props/burger_box/burger_box.vmdl";
 
@@ -27,7 +27,7 @@ public partial class ItemEntity : ModelEntity
 		item.SetWorldEntity( this );
 	}
 
-	public InventoryItem Take()
+	public IInventoryItem Take()
 	{
 		if ( IsValid && Item.IsValid() )
 		{

--- a/code/extensions/BinaryReaderExtension.cs
+++ b/code/extensions/BinaryReaderExtension.cs
@@ -7,11 +7,11 @@ namespace Conna.Inventory;
 public static partial class BinaryReaderExtension
 {
 	/// <summary>
-	/// Read an <see cref="InventoryItem"/> from a reader.
+	/// Read an <see cref="IInventoryItem"/> from a reader.
 	/// </summary>
 	/// <param name="buffer"></param>
 	/// <returns></returns>
-	public static InventoryItem ReadInventoryItem( this BinaryReader buffer )
+	public static IInventoryItem ReadInventoryItem( this BinaryReader buffer )
 	{
 		var uniqueId = buffer.ReadString();
 

--- a/code/extensions/BinaryWriterExtension.cs
+++ b/code/extensions/BinaryWriterExtension.cs
@@ -7,11 +7,11 @@ namespace Conna.Inventory;
 public static partial class BinaryWriterExtension
 {
 	/// <summary>
-	/// Write an <see cref="InventoryItem"/> into a writer.
+	/// Write an <see cref="IInventoryItem"/> into a writer.
 	/// </summary>
 	/// <param name="self"></param>
 	/// <param name="item"></param>
-	public static void Write( this BinaryWriter self, InventoryItem item )
+	public static void Write( this BinaryWriter self, IInventoryItem item )
 	{
 		if ( item != null )
 		{

--- a/code/network/NetInventoryItem.cs
+++ b/code/network/NetInventoryItem.cs
@@ -7,7 +7,7 @@ namespace Conna.Inventory;
 /// </summary>
 public class NetInventoryItem : BaseNetworkable, INetworkSerializer, IValid
 {
-	public InventoryItem Value { get; private set; }
+	public IInventoryItem Value { get; private set; }
 
 	public bool IsValid => Value.IsValid();
 	public uint Version { get; private set; }
@@ -17,7 +17,7 @@ public class NetInventoryItem : BaseNetworkable, INetworkSerializer, IValid
 
 	}
 
-	public NetInventoryItem( InventoryItem item )
+	public NetInventoryItem( IInventoryItem item )
 	{
 		Value = item;
 	}


### PR DESCRIPTION
Instead of having the `InventoryItem` class used all over the place, I've created a `IItemInventory` interface which only exposes the needed members of an `InventoryItem` in relation to the rest of the inventory system.

This will require downstream consumers to modify their code to work with `IItemInventory` but allows for consumers to only need to reference to an interface when using the inventory system, instead of the inventory item class.

This will allow consumers to do things like create derived `IInventoryItem` interfaces, which their derived item classes could then implement. For instance in the forsaken game, the interfaces such as `IPurchaseableItem` could derive from `IItemInventory` which would then simplify code such as in the Trading ui: https://github.com/Facepunch/sbox-forsaken/blob/406877b498f6f1d770069f06f630764a97ab9157/code/ui/npc/Trading.razor#L118